### PR TITLE
Correct classname in Kudu doc

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,7 +3,7 @@
 Stream Reactor
 ==============
 
-The Stream Reactor is a set of components to build a reference architecture for streaming data platforms. At it's core
+The Stream Reactor is a set of components to build a reference architecture for streaming data platforms. At its core
 is Kafka, with Kafka Connect providing a unified way to stream data in and out of the system.
 
 The actual processing if left to streaming engines and libraries such as Spark Streaming,  Apache Flink, Storm and Kafka

--- a/source/kudu.rst
+++ b/source/kudu.rst
@@ -110,7 +110,7 @@ Create a file called ``kudu-sink.properties`` with the contents below:
 .. sourcecode:: bash
 
     name=kudu-sink
-    connector.class=com.datamountaineer.streamreactor.connect.kudu.KuduSinkConnector
+    connector.class=com.datamountaineer.streamreactor.connect.kudu.sink.KuduSinkConnector
     tasks.max=1
     connect.kudu.export.route.query = INSERT INTO kudu_test SELECT * FROM kudu_test
     connect.kudu.master=quickstart
@@ -165,7 +165,7 @@ Once the connector has started lets use the kafka-connect-tools cli to post in o
 
     ➜  java -jar build/libs/kafka-connect-cli-0.6-all.jar create kudu-sink < kudu-sink.properties
     #Connector name=kudu-sink
-    connector.class=com.datamountaineer.streamreactor.connect.kudu.KuduSinkConnector
+    connector.class=com.datamountaineer.streamreactor.connect.kudu.sink.KuduSinkConnector
     tasks.max=1
     connect.kudu.master=quickstart
     connect.kudu.export.route.query = INSERT INTO kudu_test SELECT * FROM kudu_test
@@ -585,7 +585,7 @@ Example
 .. sourcecode:: bash
 
     name=kudu-sink
-    connector.class=com.datamountaineer.streamreactor.connect.kudu.KuduSinkConnector
+    connector.class=com.datamountaineer.streamreactor.connect.kudu.sink.KuduSinkConnector
     tasks.max=1
     connect.kudu.master=quickstart
     connect.kudu.export.route.query=INSERT INTO kudu_test SELECT * FROM kudu_test AUTOCREATE DISTRIBUTEBY id INTO 5 BUCKETS


### PR DESCRIPTION
Based on the [latest version I downloaded](https://github.com/datamountaineer/stream-reactor/releases/download/v0.2.2/kafka-connect-kudu-0.2-3.0.0-all.tar.gz), the classname in the docs for the kudu sink needed updating in the example code to `com.datamountaineer.streamreactor.connect.kudu.sink.KuduSinkConnector`

Also corrected an it's/its typo in the index page.