### PR TITLE
Update default for connect.cassandra.import.poll.interval

### DIFF
--- a/source/cassandra-source.rst
+++ b/source/cassandra-source.rst
@@ -551,7 +551,7 @@ Default is 1 minute.
 
 * Data type: int
 * Optional : yes
-* Default  : 1
+* Default  : 60000
 
 .. warning::
 


### PR DESCRIPTION
This now reflects the description found above. Of course the description could be with incorrect part, mostly just wanted to notify you guys of this.